### PR TITLE
swap arbitrator for arbitrableProxy

### DIFF
--- a/contracts/iarbitrableproxy.sol
+++ b/contracts/iarbitrableproxy.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@kleros/erc-792/contracts/IArbitrator.sol";
+
+/**
+ *  @title IArbitrableProxy
+ *  A general purpose arbitrable contract. Supports non-binary rulings.
+ */
+interface IArbitrableProxy {
+    function arbitrator() external view returns (IArbitrator arbitrator);
+
+    function createDispute(
+        bytes calldata _arbitratorExtraData,
+        string calldata _metaevidenceURI,
+        uint256 _numberOfRulingOptions
+    ) external payable returns (uint256 disputeID);
+
+    struct DisputeStruct {
+        bytes arbitratorExtraData;
+        bool isRuled;
+        uint256 ruling;
+        uint256 disputeIDOnArbitratorSide;
+    }
+
+    function externalIDtoLocalID(
+        uint256 _externalID
+    ) external returns (uint256 localID);
+
+    function disputes(
+        uint256 _localID
+    )
+        external
+        returns (
+            bytes memory extraData,
+            bool isRuled,
+            uint256 ruling,
+            uint256 disputeIDOnArbitratorSide
+        );
+
+    function submitEvidence(uint256 _localDisputeID, string calldata _evidenceURI) external;
+}


### PR DESCRIPTION
Instead of interfacing with an ERC-792 Arbitrator, this patch connects to an "ArbitrableProxy" contract.
https://github.com/kleros/arbitrable-proxy-contracts/

This contract allows to delegate common Arbitrable tasks (evidence submission and appeal crowdfunding logic) to a different contract on its behalf

I hope that, even if it's not what you intended, the logic is simple to follow and you can adapt it to your needs.

## Main Changes

1. Remove ERC-792 and ERC-1497 direct interfacing from `userregistry.sol` and `nftprotect.sol`
2. Remove appeals, and evidence submissions
3. Remove appeal based events
4. Make the ArbitratorRegistry register ArbitrableProxies instead.

## Observations:

### Why ArbitratorRegistry?

Why is the Arbitrator Registry available? If allowed to choose, attackers will always choose the cheapest or most vulnerable arbitrator available. Why provide the attackers with that choice? In `nftprotect.sol`, it appears creators of requests can choose whatever Arbitrator (now, ArbitrableProxy) they want

### Initial Evidence Submission

Since NFTProtect is no longer interfacing with ERC-1497, it is no longer possible to emit evidence internally. Regular evidence (the one emitted by the `Evidence(...)` event) with show when the emitter contract is the Arbitrable. In this case, the _real_ Arbitrable will be the ArbitrableProxy, not NFTProtect.

I put the evidence as a field in the events that signal the creation of events. That way, they could be highlighted and rendered as part of the Evidence Display provided in the metaevidence for those requests, or in the frontend. That way they will also be distinct from normal Evidence (since, they were the pieces of evidence that signal why the request is needed in the first place)

Some requests method didn't even require this, since you can call `arbitrableProxy.submitEvidence(...)` and make the proxy emit an Evidence event. But, you can only reliably do this when you know the disputeId of a request, and some requests didn't create disputes as soon as they were launched.

### Requests don't necessarily entail Disputes

Previously, in order to conform to ERC-792, `nftprotect.sol` needed to keep track of the `extraData` to pass it to the appeal method later. This is no longer the case.
However, there are some requests that do not launch disputes immediately upon creation. These are the ones that are created through `askOwnershipAdjustment`. This enforces the Request struct to store the `disputeId`, and keep mappings between disputeId => request.

This complexity, logic and storage overhead could be removed by removing that possibility.

### Need of storing Arbitrator

Previously, in order to call the appeals, you needed to store the `arbitrator` address. This is no longer the case, as appeals are no longer called from NFTProtect.
However, you need to store the "arbitrator" (in this case, the Arbitrable Proxy) in order to fetch the ruling.

You cannot simply store an id to an entry in the ArbitratorRegistry (to remove the need of storing many fields separatedly), because it's mutable. So, the governor of this registry could call `deleteArbitrator(...)` and then you could no longer fetch the ruling later.

### Disputes from Requests that didn't immediately launch, could launch with latest available parameters

Instead of needing to store the `extraData` and the `metaEvidence`, you could simply use the latest available parameters for these. That way you could remove those properties from the `Request` struct.